### PR TITLE
added a `preserve_order` flag to `pr.join()`

### DIFF
--- a/pyranges/methods/join.py
+++ b/pyranges/methods/join.py
@@ -3,7 +3,7 @@ import pandas as pd
 from ncls import NCLS
 
 
-def _both_indexes(scdf, ocdf, how=False):
+def _both_indexes(scdf, ocdf, how=False, **kwargs):
     assert (
         how in "containment first last outer right left".split() + [False, None]
     ) or isinstance(how, int)
@@ -42,7 +42,20 @@ def _both_indexes(scdf, ocdf, how=False):
             _self_indexes = np.concatenate([_self_indexes, filler_s])
             _other_indexes = np.concatenate([_other_indexes, missing_in_o])
 
+
+        # sort indexes if the order should be preserved
+        if kwargs["preserve_order"] and how in ["outer", "left", "right"]:
+            if how == "outer":
+                _sort_indexes = np.lexsort([_other_indexes, _other_indexes < 0, _self_indexes, _self_indexes < 0])  # to make sure "-1" indexes stay at the end
+            elif how == "left":
+                _sort_indexes = np.argsort(_self_indexes)
+            elif how == "right":
+                _sort_indexes = np.argsort(_other_indexes)
+            _self_indexes = _self_indexes[_sort_indexes]
+            _other_indexes = _other_indexes[_sort_indexes]
+
     return _self_indexes, _other_indexes
+
 
 
 def null_types(h):
@@ -79,8 +92,8 @@ def null_types(h):
     return h2
 
 
-def _both_dfs(scdf, ocdf, how=False):
-    _self_indexes, _other_indexes = _both_indexes(scdf, ocdf, how)
+def _both_dfs(scdf, ocdf, how=False, **kwargs):
+    _self_indexes, _other_indexes = _both_indexes(scdf, ocdf, how, **kwargs)
 
     if how in ["outer", "left", "right"]:
         sh = null_types(scdf.head(1))
@@ -110,15 +123,13 @@ def _both_dfs(scdf, ocdf, how=False):
 
 
 def _write_both(scdf, ocdf, **kwargs):
-    how = kwargs["how"]
-
     if scdf.empty or ocdf.empty:
-        if how in ["left", "outer"] and ocdf.empty:
+        if kwargs["how"] in ["left", "outer"] and ocdf.empty:
             ocdf = null_types(kwargs["example_header_other"])
-        elif how in ["right", "outer"] and scdf.empty:
+        elif kwargs["how"] in ["right", "outer"] and scdf.empty:
             scdf = null_types(kwargs["example_header_self"])
         # TODO: add outer
-        # elif how == "outer":
+        # elif kwargs["how"] == "outer":
         #     if scdf.empty:
         else:
             return None
@@ -128,7 +139,7 @@ def _write_both(scdf, ocdf, **kwargs):
     else:
         suffix = kwargs.get("suffixes", "_a _b".split())[1]
 
-    scdf, ocdf = _both_dfs(scdf, ocdf, how=how)
+    scdf, ocdf = _both_dfs(scdf, ocdf, **kwargs)
     nix = pd.Index(range(len(scdf)))
     scdf.index = nix
     ocdf.index = nix

--- a/pyranges/pyranges_main.py
+++ b/pyranges/pyranges_main.py
@@ -2272,6 +2272,7 @@ class PyRanges:
         suffix="_b",
         nb_cpu=1,
         apply_strand_suffix=None,
+        preserve_order=False,
     ):
         """Join PyRanges on genomic location.
 
@@ -2313,6 +2314,10 @@ class PyRanges:
 
             How many cpus to use. Can at most use 1 per chromosome or chromosome/strand tuple.
             Will only lead to speedups on large datasets.
+
+        preserve_order : bool, default False
+
+            If True, preserves the order after performing the join (only relevant in "outer", "left" and "right" joins).
 
         Returns
         -------
@@ -2408,6 +2413,7 @@ class PyRanges:
             "suffix": suffix,
             "nb_cpu": nb_cpu,
             "apply_strand_suffix": apply_strand_suffix,
+            "preserve_order": preserve_order,
         }
         if slack:
             self = self.copy()


### PR DESCRIPTION
As discussed in #303, I added a flag to `pr.join()` method to preserve the order after performing the `outer`, `left` or `right` joins.

The documentation is also updated to reflect that change.