### PR TITLE
Fixing ResourceWarning caused by unclosed file in pyranges/readers.py read_bed function (#377)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+# 0.0.132 (07.04.2024) (@Isy89)
+- Fix ResourceWarning in pyranges/readers.py function read_bed due to unclosed file. #377
+
 # 0.0.131 (04.10.2023) (@fairliereese)
 - Added option to read_gtf to rename columns that have reserved names in pyranges https://github.com/pyranges/pyranges/issues/341
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyranges"
-version = "0.0.131"
+version = "0.0.132"
 description = "GenomicRanges for Python."
 readme = "README.md"
 authors = [{ name = "Endre Bakken Stovner", email = "endbak@pm.me" },

--- a/pyranges/readers.py
+++ b/pyranges/readers.py
@@ -123,10 +123,11 @@ def read_bed(f, as_df=False, nrows=None):
 
     if f.endswith(".gz"):
         import gzip
-
-        first_start = gzip.open(f).readline().split()[1]
+        with gzip.open(f) as of:
+            first_start = of.readline().split()[1]
     else:
-        first_start = open(f).readline().split()[1]
+        with open(f) as of:
+            first_start = of.readline().split()[1]
 
     header = None
 


### PR DESCRIPTION
In pyranges/readers.py function read_bed line 127 or 129 the file is opened but never closed causing ResourceWarning.

This was fixed by wrapping the read operation within the `with` statement to ensure the file is closed.