### PR TITLE
Replace deprecated pkg_resources with importlib

### DIFF
--- a/pyranges/__init__.py
+++ b/pyranges/__init__.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 import numpy as np
 import pandas as pd
-import pkg_resources
+import importlib
 from natsort import natsorted  # type: ignore
 
 import pyranges as pr
@@ -17,7 +17,7 @@ from pyranges.multioverlap import count_overlaps
 from pyranges.pyranges_main import PyRanges
 from pyranges.readers import read_bam, read_bed, read_bigwig, read_gff3, read_gtf  # NOQA: F401
 
-__version__ = pkg_resources.get_distribution("pyranges").version
+__version__ = importlib.metadata.version("pyranges")
 
 get_example_path = data.get_example_path
 stats = statistics

--- a/pyranges/data.py
+++ b/pyranges/data.py
@@ -22,7 +22,7 @@ For printing, the PyRanges was sorted on Chromosome and Strand.
 """
 
 import pandas as pd
-import pkg_resources
+import importlib.resources
 
 import pyranges as pr
 
@@ -44,13 +44,13 @@ __all__ = [
 
 
 def get_example_path(basename):
-    full_path = pkg_resources.resource_filename("pyranges", "example_data/{}".format(basename))
+    full_path = importlib.resources.files("pyranges").joinpath("example_data/{}".format(basename))
 
-    if full_path.endswith(".bam"):
+    if full_path.suffix == ".bam":
         # hack to load index too
-        pkg_resources.resource_filename("pyranges", "example_data/{}.bai".format(basename))
+        importlib.resources.files("pyranges").joinpath("example_data/{}.bai".format(basename))
 
-    return full_path
+    return str(full_path)
 
 
 def aorta():


### PR DESCRIPTION
`setuptools` recently deprecated `pkg_resources`, and instead recommends `importlib` (available since Python 3.7).

Without this update, tests and packages relying on `pyranges` break (in part because setuptools is not declared as a dependency).

I think this approach is preferrable over #390, since pkg_resources is deprecated: https://setuptools.pypa.io/en/latest/pkg_resources.html

![image](https://github.com/user-attachments/assets/4ac43726-3e1c-4de1-bd7b-7a56a3b765ca)
