### PR TITLE
Fix importlib error in older python introduced in #393

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+# 0.0.136 (11.03.2025)
+- Fix regression on importlib.metadata that create an AttributeError on py<3.13
+
+# 0.0.135 (10.05.2025)
+- Replace deprecated pkg_resources with importlib
+
 # 0.0.135 (10.05.2025)
 - Replace deprecated pkg_resources with importlib
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyranges"
-version = "0.1.3"
+version = "0.1.4"
 description = "GenomicRanges for Python."
 readme = "README.md"
 authors = [{ name = "Endre Bakken Stovner", email = "endbak@pm.me" },

--- a/pyranges/__init__.py
+++ b/pyranges/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-import importlib
+import importlib.metadata
 import sys
 from collections import defaultdict
 

--- a/tests/tutorial_doctest/test_how_to_pages.py
+++ b/tests/tutorial_doctest/test_how_to_pages.py
@@ -1,5 +1,4 @@
 import doctest
-import os
 from pathlib import Path
 
 


### PR DESCRIPTION
In python 3.11 (and I would assume earlier python too), `metadata` is not an attribute of `importlib` so instead of 

```python
import importlib
importlib.metadata
```

you have to explicitely do:

```python
import importlib.metadata
importlib.metadata
```

Thus #393 introduces a bug on py<3.13.

Would it be possible to use a python matrix CI github action to prevent this in the future ?

Also if we python <3.8 is still supported then likely needs to have fallback into `importlib-metadata` and `importlib-resources`. 